### PR TITLE
feature/DTE 837 save input file to output bucket

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -38,6 +38,18 @@ data "aws_iam_policy_document" "court_document_parse_machine_policy" {
 
   statement {
     actions = [
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:PutObject",
+      "s3:PutObjectTagging"
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
       "xray:PutTraceSegments",
       "xray:PutTelemetryRecords",
       "xray:GetSamplingRules",

--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -24,7 +24,7 @@
       "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
       "Parameters": {
         "Bucket.$": "$.output.required.parameters.s3Bucket",
-        "Key.$": "$.output.required.parameters.s3FolderName",
+        "Key.$":"States.Format('{}{}', $.output.required.parameters.s3FolderName, States.ArrayGetItem(States.StringSplit($.parameters.s3Key, '/'), States.MathAdd(States.ArrayLength(States.StringSplit($.parameters.s3Key, '/')), -1)))",
         "CopySource.$": "States.Format('{}/{}',$.parameters.s3Bucket,$.parameters.s3Key)"
       },
       "Catch" : [

--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -16,8 +16,26 @@
           "parameters": {}
         }
       },
-      "Next": "Check optional output parameter",
+      "Next": "Save input file to output bucket",
       "ResultPath": "$.output"
+    },
+    "Save input file to output bucket": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
+      "Parameters": {
+        "Bucket.$": "$.output.required.parameters.s3Bucket",
+        "Key.$": "$.output.required.parameters.s3FolderName",
+        "CopySource.$": "States.Format('{}/{}',$.parameters.s3Bucket,$.parameters.s3Key)"
+      },
+      "Catch" : [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Check optional output parameter",
+          "ResultPath": null
+        }
+      ],
+      "ResultPath": null,
+      "Next": "Check optional output parameter"
     },
     "Check optional output parameter": {
       "Type": "Choice",


### PR DESCRIPTION
- feat: Copy FCL input file for parse request to output s3 folder
- Extract file name from initial s3 key

## Test Plan

Edited step function in AWS ui, ran integration tests in da-system-testing through PTE. Observed successful execution of step function through happy and unhappy paths, and the saving of the original file in the desired location in s3.