### PR TITLE
feat: Save parser outputs json file to working folder as part of parse court documents step function

### DIFF
--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -124,7 +124,7 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Check for parser errors",
+      "Next": "Save parser outputs to s3",
       "Catch": [
         {
           "ErrorEquals": [
@@ -134,6 +134,17 @@
           "ResultPath": "$.lambda-output.payload.parameters.errors"
         }
       ]
+    },
+    "Save parser outputs to s3": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
+      "Parameters": {
+        "Bucket.$": "$.output.required.parameters.s3Bucket",
+        "Key.$": "States.Format('{}/{}', $.output.required.parameters.s3FolderName, 'parser-outputs.json')",
+        "Body.$": "$.parser-outputs"
+      },
+      "Next": "Check for parser errors",
+      "ResultPath": null
     },
     "Check for parser errors": {
       "Type": "Choice",


### PR DESCRIPTION
This should pave the way for adding images back into the final package and referencing them in the metadata. 

We can also refactor the pre-packer to be a little nicer in referencing files referred to in the parser output json rather than just looking for, eg, an xml file, and assuming it is the one we are looking for. 

It should also be pretty simple to add the error messages back into the metadata, which dropped out from v1.

## Test Plan
Ran through happy and unhappy path with system testing repo, verified parser output json created as and where expected.