### PR TITLE
DTE-860: parser kms sample data

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -168,15 +168,19 @@ resource  "aws_iam_policy" "parser_lambda_s3_policy" {
 }
 
 data "aws_iam_policy_document" "read_s3-bucket-input" {
-  statement {
-    effect =  "Allow"
-    actions   = ["s3:GetObject"]
-    resources = [
-      "arn:aws:s3:::${var.parse_s3_bucket_input}",
-      "arn:aws:s3:::${var.parse_s3_bucket_input}/*"
-    ]
+  dynamic "statement" {
+    for_each = var.parse_s3_bucket_input
+    content {
+      effect    = "Allow"
+      actions   = ["s3:GetObject"]
+      resources = [
+        "arn:aws:s3:::${statement.value}",
+        "arn:aws:s3:::${statement.value}/*"
+      ]
+    }
   }
 }
+
 resource "aws_iam_role_policy_attachment" "court_document_lambda_s3_input" {
   role      = aws_iam_role.court_document_parse_lambda_role.name
   policy_arn = aws_iam_policy.parser_lambda_s3_policy.arn

--- a/iam.tf
+++ b/iam.tf
@@ -84,6 +84,27 @@ resource "aws_iam_role_policy_attachment" "court_document_parse_lambda_logs" {
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 
+data "aws_iam_policy_document" "court_document_parse_lambda_kms_policy_data" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = var.s3_bucket_kms_arns
+  }
+}
+
+resource "aws_iam_policy" "court_document_parse_lambda_kms_policy" {
+  name        = "${var.env}-${var.prefix}-court-document-parse-s3-key"
+  description = "The KMS key policy for court document parse lambda"
+  policy      = data.aws_iam_policy_document.court_document_parse_lambda_kms_policy_data.json
+}
+
+resource "aws_iam_role_policy_attachment" "court_document_parse_lambda_key" {
+  role       = aws_iam_role.court_document_parse_lambda_role.name
+  policy_arn = aws_iam_policy.court_document_parse_lambda_kms_policy.arn
+}
+
 # Role for the parse-judgment step-function trigger
 resource "aws_iam_role" "court_document_parse_trigger" {
   name                 = "${var.env}-${var.prefix}-court-document-parse-trigger-lambda-role"

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,8 @@ variable "parse_s3_bucket_input" {
   description = "The s3 input bucket "
   type        = string
 }
+
+variable "s3_bucket_kms_arns" {
+  description = "arns of kms for buckets parser lambda will read from (sample data bucket used in tests, and in future fcl input bucket) "
+  type        = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -64,8 +64,8 @@ variable "tre_data_bucket" {
 }
 
 variable "parse_s3_bucket_input" {
-  description = "The s3 input bucket "
-  type        = string
+  description = "Allowable s3 input buckets for parser"
+  type        = list(string)
 }
 
 variable "s3_bucket_kms_arns" {


### PR DESCRIPTION
The parser can currently only take input from FCL bucket and we want it to also be able to take from sample data bucket

This will:
- allow the parser to get from a list of buckets (the list comes from tf vars and is FCL bucket as now + sample data bucket)
- allow the parser lambda to use KMS on the sample data bucket

